### PR TITLE
`feat: Implement 'fuck' command to curse other players`

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,7 @@ from app.handlers.abort import abort_command, abort_no_query, abort_yes_query
 from app.handlers.add_user import add_user_command
 from app.handlers.coffee_ready import coffee_ready_command
 from app.handlers.dice import dice_handler, no_play_dice_query, yes_play_dice_query
+from app.handlers.fuck import fuck_command
 from app.handlers.game import play_command, play_no_query, play_yes_query
 from app.handlers.game_over import game_over_command
 from app.handlers.ignore import ignore_command
@@ -39,6 +40,7 @@ async def configure(bot: telegram.Bot):
         ("ranking", "Ranking haciendo café"),
         ("abort", "Abortar un juego."),
         ("info", "Información del juego"),
+        ("fuck", "Joder al próximo que saque un número igual o menor que el tuyo"),
     ]
     await bot.set_my_commands(
         commands=common_commands, scope=telegram.BotCommandScopeAllGroupChats()
@@ -94,6 +96,7 @@ def configure_handlers(application: Application):
     application.add_handler(
         CommandHandler(command="gameOver", callback=game_over_command)
     )
+    application.add_handler(CommandHandler(command="fuck", callback=fuck_command))
     application.add_handler(CallbackQueryHandler(start_query, pattern="start"))
     application.add_handler(
         CallbackQueryHandler(play_yes_query, pattern="game_yes_play")

--- a/app/handlers/dice.py
+++ b/app/handlers/dice.py
@@ -5,6 +5,7 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 from app.services.chat import Chat, game_over_message, start_params, user_not_active
+from app.services.fuck_service import FuckService
 
 
 def get_buttons(user_id):
@@ -40,35 +41,12 @@ async def dice_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
     chat.register_point()
 
-    current_username = chat.active_username
-    current_dice_value = chat.dice_value
-
-    fuck_users = []
-    for username, user_data in chat._users.items():
-        if (username != current_username and
-            user_data.get("fuck_active", False) and
-            current_dice_value <= user_data.get("fuck_value", 6)):
-            fuck_users.append(username)
-
-    if fuck_users:
-        emojis = ["💩", "🖕", "🤡", "👹", "💀", "😈", "🤬", "🔪", "👺", "🤮"]
-        emoji = random.choice(emojis)
-
-        reactions = [
-            "¡Te jodieron!",
-            "¡Alguien te ha dado una maldición!",
-            "¡Qué mal número, te han jodido!",
-            "¡Alguien está feliz de verte sufrir!",
-            "¡Mala suerte, te han maldecido!"
-        ]
-        reaction = random.choice(reactions)
-
-        for username in fuck_users:
-            chat._users[username]["fuck_active"] = False
-
-        await update.effective_message.reply_text(
-            text=f"{reaction} {emoji} {' '.join(fuck_users)} está disfrutando tu infortunio."
-        )
+    await FuckService.process_fuck_triggers(
+        update=update,
+        users_data=chat._users,
+        current_username=chat.active_username,
+        current_dice_value=chat.dice_value
+    )
 
     if chat.is_the_last_user():
         users = chat.game_over()

--- a/app/handlers/dice.py
+++ b/app/handlers/dice.py
@@ -1,4 +1,5 @@
 import time
+import random
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
@@ -38,6 +39,37 @@ async def dice_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             text="No puedes votar en esta ronda.",
         )
     chat.register_point()
+
+    current_username = chat.active_username
+    current_dice_value = chat.dice_value
+
+    fuck_users = []
+    for username, user_data in chat._users.items():
+        if (username != current_username and
+            user_data.get("fuck_active", False) and
+            current_dice_value <= user_data.get("fuck_value", 6)):
+            fuck_users.append(username)
+
+    if fuck_users:
+        emojis = ["💩", "🖕", "🤡", "👹", "💀", "😈", "🤬", "🔪", "👺", "🤮"]
+        emoji = random.choice(emojis)
+
+        reactions = [
+            "¡Te jodieron!",
+            "¡Alguien te ha dado una maldición!",
+            "¡Qué mal número, te han jodido!",
+            "¡Alguien está feliz de verte sufrir!",
+            "¡Mala suerte, te han maldecido!"
+        ]
+        reaction = random.choice(reactions)
+
+        for username in fuck_users:
+            chat._users[username]["fuck_active"] = False
+
+        await update.effective_message.reply_text(
+            text=f"{reaction} {emoji} {' '.join(fuck_users)} está disfrutando tu infortunio."
+        )
+
     if chat.is_the_last_user():
         users = chat.game_over()
         time.sleep(5)

--- a/app/handlers/fuck.py
+++ b/app/handlers/fuck.py
@@ -1,0 +1,69 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+import random
+
+from app.services.chat import Chat, user_not_active
+
+
+async def fuck_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """
+    Command that takes the value of the dice and sends a reaction and emoji
+    to the next person that gets a number like yours or less.
+    If the user has lost the game, it just sends random angry emojis.
+    Only users with dice values of 1 or 2 can use this command.
+    """
+    chat = await Chat.get_instance(update, context)
+    if not chat.is_active_user():
+        return await user_not_active(update)
+
+    username = chat.active_username
+
+    user_data = chat._users.get(username, {})
+    user_has_lost = user_data.get("score", 0) > 0
+
+    if user_has_lost:
+        angry_emojis = ["💢", "🤬", "😡", "👿", "😤", "😠", "💥", "🔥", "👹", "👺"]
+        angry_symbols = ["grrrr", "argh", "maldición", "!!!!", "@#$%&!", "¡¡¡$#@!!!", "ufff"]
+
+        emojis = " ".join(random.sample(angry_emojis, k=min(3, len(angry_emojis))))
+        symbol = random.choice(angry_symbols)
+
+        return await update.effective_message.reply_text(
+            text=f"{emojis} {symbol} {emojis}"
+        )
+
+    if not chat.has_open_game():
+        return await update.effective_message.reply_text(
+            text="No hay una partida abierta. Inicia una con /play primero."
+        )
+
+    if not chat.user_has_dice():
+        return await update.effective_message.reply_text(
+            text="Debes lanzar el dado primero."
+        )
+
+    # Check if the user has already used the fuck command in this game
+    if user_data.get("fuck_active", False):
+        return await update.effective_message.reply_text(
+            text="¡No te pases! 🤡"
+        )
+
+    dice_value = chat.dice_value
+
+    # Check if the dice value is 1 or 2
+    if dice_value not in [1, 2]:
+        return await update.effective_message.reply_text(
+            text="Solo puedes usar este comando si sacaste 1 o 2 en el dado."
+        )
+
+    if username not in chat._users:
+        chat._users[username] = {}
+
+    chat._users[username]["fuck_active"] = True
+    chat._users[username]["fuck_value"] = dice_value
+
+    await chat.save()
+
+    return await update.effective_message.reply_text(
+        text=f"¡Preparado para joder! 😈 Cuando alguien saque {dice_value} o menos, recibirá tu maldición."
+    )

--- a/app/handlers/fuck.py
+++ b/app/handlers/fuck.py
@@ -3,6 +3,7 @@ from telegram.ext import ContextTypes
 import random
 
 from app.services.chat import Chat, user_not_active
+from app.services.fuck_service import FuckService
 
 
 async def fuck_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -18,15 +19,13 @@ async def fuck_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     username = chat.active_username
 
+    # Check if the user has lost by examining their score in the ranking
+    # This is consistent with how users are checked in game_over_message
     user_data = chat._users.get(username, {})
     user_has_lost = user_data.get("score", 0) > 0
 
     if user_has_lost:
-        angry_emojis = ["💢", "🤬", "😡", "👿", "😤", "😠", "💥", "🔥", "👹", "👺"]
-        angry_symbols = ["grrrr", "argh", "maldición", "!!!!", "@#$%&!", "¡¡¡$#@!!!", "ufff"]
-
-        emojis = " ".join(random.sample(angry_emojis, k=min(3, len(angry_emojis))))
-        symbol = random.choice(angry_symbols)
+        emojis, symbol = FuckService.get_angry_emotes()
 
         return await update.effective_message.reply_text(
             text=f"{emojis} {symbol} {emojis}"
@@ -42,7 +41,6 @@ async def fuck_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             text="Debes lanzar el dado primero."
         )
 
-    # Check if the user has already used the fuck command in this game
     if user_data.get("fuck_active", False):
         return await update.effective_message.reply_text(
             text="¡No te pases! 🤡"
@@ -50,10 +48,9 @@ async def fuck_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     dice_value = chat.dice_value
 
-    # Check if the dice value is 1 or 2
-    if dice_value not in [1, 2]:
+    if not FuckService.is_valid_dice_value(dice_value):
         return await update.effective_message.reply_text(
-            text="Solo puedes usar este comando si sacaste 1 o 2 en el dado."
+            text="Vamos, no llores tanto, ganate el privilegio de usar el comando, tira un 1 o un 2."
         )
 
     if username not in chat._users:
@@ -67,3 +64,4 @@ async def fuck_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     return await update.effective_message.reply_text(
         text=f"¡Preparado para joder! 😈 Cuando alguien saque {dice_value} o menos, recibirá tu maldición."
     )
+ 

--- a/app/services/fuck_service.py
+++ b/app/services/fuck_service.py
@@ -1,0 +1,130 @@
+import random
+from typing import List, Tuple, Dict, Any, Optional
+
+from telegram import Update
+
+
+class FuckService:
+    """Service for handling 'fuck' command functionality."""
+    
+    @staticmethod
+    def get_users_to_trigger(current_username: str, users_data: Dict[str, Dict[str, Any]], current_dice_value: int) -> List[str]:
+        """
+        Get the list of users who have an active fuck command that should be triggered.
+        
+        Args:
+            current_username: Username of the current user
+            users_data: Dictionary of user data
+            current_dice_value: Current dice value
+            
+        Returns:
+            List of usernames that have active fuck commands that should be triggered
+        """
+        fuck_users = []
+        for username, user_data in users_data.items():
+            # Skip if this is the current user
+            if username == current_username:
+                continue
+                
+            # Skip if the user doesn't have an active fuck command
+            if not user_data.get("fuck_active", False):
+                continue
+                
+            # Check if the current dice value triggers this user's fuck command
+            if current_dice_value <= user_data.get("fuck_value", 6):
+                fuck_users.append(username)
+                
+        return fuck_users
+    
+    @staticmethod
+    def get_random_reaction() -> Tuple[str, str]:
+        """
+        Get a random emoji and reaction message.
+        
+        Returns:
+            Tuple of (emoji, reaction_message)
+        """
+        emojis = ["💩", "🖕", "🤡", "👹", "💀", "😈", "🤬", "🔪", "👺", "🤮"]
+        emoji = random.choice(emojis)
+        
+        reactions = [
+            "¡Te jodieron!",
+            "¡Alguien te ha dado una maldición!",
+            "¡Qué mal número, te han jodido!",
+            "¡Alguien está feliz de verte sufrir!",
+            "¡Mala suerte, te han maldecido!"
+        ]
+        reaction = random.choice(reactions)
+        
+        return emoji, reaction
+    
+    @staticmethod
+    def deactivate_fuck_commands(users_data: Dict[str, Dict[str, Any]], usernames: List[str]) -> None:
+        """
+        Deactivate fuck commands for the specified users.
+        
+        Args:
+            users_data: Dictionary of user data
+            usernames: List of usernames to deactivate fuck commands for
+        """
+        for username in usernames:
+            if username in users_data:
+                users_data[username]["fuck_active"] = False
+    
+    @staticmethod
+    def get_angry_emotes() -> Tuple[str, str]:
+        """
+        Get random angry emojis and symbols for users who have lost.
+        
+        Returns:
+            Tuple of (emojis, symbol)
+        """
+        angry_emojis = ["💢", "🤬", "😡", "👿", "😤", "😠", "💥", "🔥", "👹", "👺"]
+        angry_symbols = ["grrrr", "argh", "maldición", "!!!!", "@#$%&!", "¡¡¡$#@!!!", "ufff"]
+        
+        emojis = " ".join(random.sample(angry_emojis, k=min(3, len(angry_emojis))))
+        symbol = random.choice(angry_symbols)
+        
+        return emojis, symbol
+    
+    @staticmethod
+    def is_valid_dice_value(dice_value: int) -> bool:
+        """
+        Check if the dice value is valid for using the fuck command.
+        
+        Args:
+            dice_value: Dice value to check
+            
+        Returns:
+            True if the dice value is valid (1 or 2), False otherwise
+        """
+        return dice_value in [1, 2]
+    
+    @staticmethod
+    async def process_fuck_triggers(update: Update, users_data: Dict[str, Dict[str, Any]], 
+                               current_username: str, current_dice_value: int) -> None:
+        """
+        Process triggers for fuck commands.
+        
+        Args:
+            update: Telegram update
+            users_data: Dictionary of user data
+            current_username: Username of the current user
+            current_dice_value: Current dice value
+        """
+        fuck_users = FuckService.get_users_to_trigger(
+            current_username, users_data, current_dice_value
+        )
+        
+        if not fuck_users:
+            return
+        
+        emoji, reaction = FuckService.get_random_reaction()
+        
+        # Deactivate the fuck commands
+        FuckService.deactivate_fuck_commands(users_data, fuck_users)
+        
+        # Send the message
+        await update.effective_message.reply_text(
+            text=f"{reaction} {emoji} {' '.join(fuck_users)} está disfrutando tu infortunio."
+        ) 

--- a/tests/handlers/game/test_dice_handler_with_fuck.py
+++ b/tests/handlers/game/test_dice_handler_with_fuck.py
@@ -1,0 +1,155 @@
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from app.handlers.dice import dice_handler
+from tests.util import get_chat
+
+
+@pytest.mark.asyncio
+@patch("random.choice", side_effect=["💩", "¡Te jodieron!"])
+@patch("app.handlers.dice.game_over_message", return_value=None)
+@patch("time.sleep", return_value=None)
+async def test_dice_handler_with_fuck_active(mock_sleep, mock_game_over, mock_random_choice):
+    """Test dice handler when a user has an active fuck command"""
+    tester = await get_chat(
+        {
+            "users": {
+                "@aaa": {"data": 1, "fuck_active": True, "fuck_value": 4},
+                "@bbb": {"data": 1},
+            },
+            "active_users": ["@aaa", "@bbb"],
+            "cycles": [
+                {
+                    "points": {"@aaa": {"message_id": 5555, "value": 4}},
+                    "users": ["@aaa", "@bbb"],
+                }
+            ],
+            "last_play_date": None,
+        },
+        username="bbb",
+        message_id=6666,
+        message_value=3,  # Lower than the fuck_value (4)
+    )
+    
+    await dice_handler(tester.update, tester.context)
+    
+    # Should trigger the fuck message
+    tester.update.effective_message.reply_text.assert_any_call(
+        text="¡Te jodieron! 💩 @aaa está disfrutando tu infortunio."
+    )
+    
+    # The fuck_active should be set to False after use
+    await tester.assert_save(
+        {
+            "last_play_date": None,
+            "users": {
+                "@aaa": {"data": 1, "fuck_active": False, "fuck_value": 4},
+                "@bbb": {"data": 1, "score": 1},
+            },
+            "active_users": ["@aaa", "@bbb"],
+            "cycles": [],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch("app.handlers.dice.game_over_message", return_value=None)
+@patch("time.sleep", return_value=None)
+async def test_dice_handler_with_fuck_not_triggered(mock_sleep, mock_game_over):
+    """Test dice handler when a user has an active fuck command but the dice value is higher"""
+    tester = await get_chat(
+        {
+            "users": {
+                "@aaa": {"data": 1, "fuck_active": True, "fuck_value": 2},
+                "@bbb": {"data": 1},
+            },
+            "active_users": ["@aaa", "@bbb"],
+            "cycles": [
+                {
+                    "points": {"@aaa": {"message_id": 5555, "value": 2}},
+                    "users": ["@aaa", "@bbb"],
+                }
+            ],
+            "last_play_date": None,
+        },
+        username="bbb",
+        message_id=6666,
+        message_value=5,  # Higher than the fuck_value (2), so it shouldn't trigger
+    )
+    
+    await dice_handler(tester.update, tester.context)
+    
+    # Get all calls to reply_text
+    call_args_list = tester.update.effective_message.reply_text.call_args_list
+    
+    # Make sure no fuck message was sent
+    for call in call_args_list:
+        args, kwargs = call
+        if kwargs.get('text') and 'jodieron' in kwargs.get('text'):
+            pytest.fail("Fuck message was triggered when it shouldn't have been")
+    
+    # The fuck_active should still be True
+    await tester.assert_save(
+        {
+            "last_play_date": None,
+            "users": {
+                "@aaa": {"data": 1, "fuck_active": True, "fuck_value": 2, "score": 1},
+                "@bbb": {"data": 1},
+            },
+            "active_users": ["@aaa", "@bbb"],
+            "cycles": [],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch("random.choice", side_effect=["🤡", "¡Qué mal número, te han jodido!"])
+@patch("app.handlers.dice.game_over_message", return_value=None)
+@patch("time.sleep", return_value=None)
+async def test_dice_handler_with_multiple_fuck_active(mock_sleep, mock_game_over, mock_random_choice):
+    """Test dice handler when multiple users have active fuck commands"""
+    tester = await get_chat(
+        {
+            "users": {
+                "@aaa": {"data": 1, "fuck_active": True, "fuck_value": 4},
+                "@bbb": {"data": 1},
+                "@ccc": {"data": 1, "fuck_active": True, "fuck_value": 3},
+            },
+            "active_users": ["@aaa", "@bbb", "@ccc"],
+            "cycles": [
+                {
+                    "points": {
+                        "@aaa": {"message_id": 5555, "value": 4},
+                        "@ccc": {"message_id": 7777, "value": 3},
+                    },
+                    "users": ["@aaa", "@bbb", "@ccc"],
+                }
+            ],
+            "last_play_date": None,
+        },
+        username="bbb",
+        message_id=6666,
+        message_value=2,  # Lower than both fuck_values, should trigger both
+    )
+    
+    await dice_handler(tester.update, tester.context)
+    
+    # Should trigger the fuck message from both users
+    tester.update.effective_message.reply_text.assert_any_call(
+        text="¡Qué mal número, te han jodido! 🤡 @aaa @ccc está disfrutando tu infortunio."
+    )
+    
+    # Both fuck_active flags should be set to False after use
+    await tester.assert_save(
+        {
+            "last_play_date": None,
+            "users": {
+                "@aaa": {"data": 1, "fuck_active": False, "fuck_value": 4},
+                "@bbb": {"data": 1, "score": 1},
+                "@ccc": {"data": 1, "fuck_active": False, "fuck_value": 3},
+            },
+            "active_users": ["@aaa", "@bbb", "@ccc"],
+            "cycles": [],
+        }
+    ) 

--- a/tests/handlers/test_fuck.py
+++ b/tests/handlers/test_fuck.py
@@ -1,0 +1,126 @@
+import pytest
+from unittest.mock import patch, ANY
+
+from app.handlers.fuck import fuck_command
+from tests.util import get_chat
+
+
+@pytest.mark.asyncio
+async def test_no_is_active_user():
+    tester = await get_chat(
+        {"users": {"@aaa": {"data": 1}}, "active_users": ["@aaa"]},
+        username="bbb",
+    )
+    await fuck_command(tester.update, tester.context)
+    tester.assert_reply_text(text="Tu usuario no está activo. Adiciónalo primero.")
+
+
+@pytest.mark.asyncio
+async def test_no_has_open_game():
+    tester = await get_chat(
+        {"users": {"@aaa": {"data": 1}}, "active_users": ["@aaa"]},
+        username="aaa",
+    )
+    await fuck_command(tester.update, tester.context)
+    tester.assert_reply_text(
+        text="No hay una partida abierta. Inicia una con /play primero."
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_has_dice():
+    tester = await get_chat(
+        {
+            "users": {"@aaa": {"data": 1}},
+            "active_users": ["@aaa"],
+            "cycles": [{"points": {}, "users": ["@aaa"]}],
+        },
+        username="aaa",
+    )
+    await fuck_command(tester.update, tester.context)
+    tester.assert_reply_text(text="Debes lanzar el dado primero.")
+
+
+@pytest.mark.asyncio
+async def test_success():
+    tester = await get_chat(
+        {
+            "users": {"@aaa": {"data": 1}},
+            "active_users": ["@aaa"],
+            "cycles": [{"points": {"@aaa": {"message_id": 123, "value": 2}}, "users": ["@aaa"]}],
+            "last_play_date": None,
+        },
+        username="aaa",
+        message_value=2,
+    )
+    await fuck_command(tester.update, tester.context)
+    tester.assert_reply_text(
+        text="¡Preparado para joder! 😈 Cuando alguien saque 2 o menos, recibirá tu maldición."
+    )
+    await tester.assert_save(
+        {
+            "last_play_date": None,
+            "users": {"@aaa": {"data": 1, "fuck_active": True, "fuck_value": 2}},
+            "active_users": ["@aaa"],
+            "cycles": [{"users": ["@aaa"], "points": {"@aaa": {"message_id": 123, "value": 2}}}],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch("random.sample", return_value=["💢", "😡", "😤"])
+@patch("random.choice", return_value="maldición")
+async def test_user_has_lost(mock_choice, mock_sample):
+    """Test that when a user has lost (has a score), they just send angry emojis"""
+    tester = await get_chat(
+        {
+            "users": {"@aaa": {"data": 1, "score": 2}},  # User has a score, meaning they've lost
+            "active_users": ["@aaa"],
+            "last_play_date": None,
+        },
+        username="aaa",
+    )
+    await fuck_command(tester.update, tester.context)
+    tester.assert_reply_text(
+        text="💢 😡 😤 maldición 💢 😡 😤"
+    )
+    # No need to check for save as it doesn't save anything in this case 
+
+
+@pytest.mark.asyncio
+async def test_already_active():
+    """Test that when a user tries to use the command twice, they get the 'No te pases!' message"""
+    tester = await get_chat(
+        {
+            "users": {"@aaa": {"data": 1, "fuck_active": True, "fuck_value": 2}},  # Already has fuck_active
+            "active_users": ["@aaa"],
+            "cycles": [{"points": {"@aaa": {"message_id": 123, "value": 2}}, "users": ["@aaa"]}],
+            "last_play_date": None,
+        },
+        username="aaa",
+        message_value=2,
+    )
+    await fuck_command(tester.update, tester.context)
+    tester.assert_reply_text(
+        text="¡No te pases! 🤡"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dice_value_not_allowed():
+    """Test that users with dice values other than 1 or 2 cannot use the command"""
+    tester = await get_chat(
+        {
+            "users": {"@aaa": {"data": 1}},
+            "active_users": ["@aaa"],
+            "cycles": [{"points": {"@aaa": {"message_id": 123, "value": 4}}, "users": ["@aaa"]}],
+            "last_play_date": None,
+        },
+        username="aaa",
+        message_value=4,  # Using invalid value (4) - only 1 and 2 are allowed
+    )
+    await fuck_command(tester.update, tester.context)
+    tester.assert_reply_text(
+        text="Solo puedes usar este comando si sacaste 1 o 2 en el dado."
+    )
+    # No changes should be saved to the state

--- a/tests/services/test_fuck_service.py
+++ b/tests/services/test_fuck_service.py
@@ -1,0 +1,96 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from app.services.fuck_service import FuckService
+
+
+def test_get_users_to_trigger():
+    # Test with no users to trigger
+    current_username = "@current"
+    users_data = {
+        "@current": {"data": 1},
+        "@user1": {"data": 1},
+        "@user2": {"data": 1, "fuck_active": True, "fuck_value": 2},
+    }
+    current_dice_value = 3  # Higher than the fuck_value
+
+    result = FuckService.get_users_to_trigger(current_username, users_data, current_dice_value)
+    assert result == []
+
+    # Test with one user to trigger
+    current_dice_value = 2  # Equal to the fuck_value
+    result = FuckService.get_users_to_trigger(current_username, users_data, current_dice_value)
+    assert result == ["@user2"]
+
+    # Test with two users to trigger
+    users_data["@user3"] = {"data": 1, "fuck_active": True, "fuck_value": 3}
+    result = FuckService.get_users_to_trigger(current_username, users_data, current_dice_value)
+    assert result == ["@user2", "@user3"]
+
+
+def test_get_random_reaction():
+    # Test that the function returns a tuple of two strings
+    with patch("random.choice", side_effect=["💩", "¡Te jodieron!"]):
+        emoji, reaction = FuckService.get_random_reaction()
+        assert emoji == "💩"
+        assert reaction == "¡Te jodieron!"
+
+
+def test_deactivate_fuck_commands():
+    # Test that the function deactivates fuck commands
+    users_data = {
+        "@user1": {"data": 1, "fuck_active": True, "fuck_value": 2},
+        "@user2": {"data": 1, "fuck_active": True, "fuck_value": 3},
+        "@user3": {"data": 1},
+    }
+    usernames = ["@user1", "@user2", "@nonexistent"]
+
+    FuckService.deactivate_fuck_commands(users_data, usernames)
+
+    assert users_data["@user1"]["fuck_active"] is False
+    assert users_data["@user2"]["fuck_active"] is False
+    # @user3 should not be affected
+    assert "fuck_active" not in users_data["@user3"]
+
+
+def test_get_angry_emotes():
+    # Test that the function returns a tuple of two strings
+    with patch("random.sample", return_value=["💢", "😡", "😤"]):
+        with patch("random.choice", return_value="maldición"):
+            emojis, symbol = FuckService.get_angry_emotes()
+            assert emojis == "💢 😡 😤"
+            assert symbol == "maldición"
+
+
+def test_is_valid_dice_value():
+    # Test that the function correctly identifies valid dice values
+    assert FuckService.is_valid_dice_value(1) is True
+    assert FuckService.is_valid_dice_value(2) is True
+    assert FuckService.is_valid_dice_value(3) is False
+    assert FuckService.is_valid_dice_value(0) is False
+
+
+@pytest.mark.asyncio
+async def test_process_fuck_triggers():
+    # Test with no users to trigger
+    update = AsyncMock()
+    users_data = {
+        "@current": {"data": 1},
+        "@user1": {"data": 1, "fuck_active": True, "fuck_value": 2},
+    }
+    current_username = "@current"
+    current_dice_value = 3  # Higher than the fuck_value
+
+    with patch.object(FuckService, "get_users_to_trigger", return_value=[]):
+        await FuckService.process_fuck_triggers(update, users_data, current_username, current_dice_value)
+        update.effective_message.reply_text.assert_not_called()
+
+    # Test with users to trigger
+    with patch.object(FuckService, "get_users_to_trigger", return_value=["@user1"]):
+        with patch.object(FuckService, "get_random_reaction", return_value=("💩", "¡Te jodieron!")):
+            with patch.object(FuckService, "deactivate_fuck_commands") as mock_deactivate:
+                await FuckService.process_fuck_triggers(update, users_data, current_username, current_dice_value)
+                update.effective_message.reply_text.assert_called_once_with(
+                    text="¡Te jodieron! 💩 @user1 está disfrutando tu infortunio."
+                )
+                mock_deactivate.assert_called_once_with(users_data, ["@user1"]) 


### PR DESCRIPTION
This commit introduces the 'fuck' command, which allows players with a dice roll of 1 or 2 to curse the next player who rolls a number equal to or lower than their roll.  This adds a new layer of interaction and strategy to the game.

The commit also includes tests for the new command and modifications to the dice handler to trigger the curse when appropriate.